### PR TITLE
feat: add automatic dependency installation to start-system.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ You can quickly view how this works by running this repositories .claude setup.
 ```bash
 # 1. Start both server and client
 ./scripts/start-system.sh
+# Note: Dependencies will be automatically installed on first run
 
 # 2. Open http://localhost:5173 in your browser
 
@@ -139,7 +140,7 @@ claude-code-hooks-multi-agent-observability/
 │   └── settings.json      # Hook configuration
 │
 ├── scripts/               # Utility scripts
-│   ├── start-system.sh   # Launch server & client
+│   ├── start-system.sh   # Launch server & client (auto-installs dependencies)
 │   ├── reset-system.sh   # Stop all processes
 │   └── test-system.sh    # System validation
 │

--- a/scripts/start-system.sh
+++ b/scripts/start-system.sh
@@ -38,6 +38,13 @@ fi
 # Start server
 echo -e "\n${GREEN}Starting server on port 4000...${NC}"
 cd "$PROJECT_ROOT/apps/server"
+
+# Check and install server dependencies if needed
+if [ ! -d "node_modules" ]; then
+    echo -e "${YELLOW}Installing server dependencies...${NC}"
+    bun install
+fi
+
 bun run dev &
 SERVER_PID=$!
 
@@ -54,6 +61,13 @@ done
 # Start client
 echo -e "\n${GREEN}Starting client on port 5173...${NC}"
 cd "$PROJECT_ROOT/apps/client"
+
+# Check and install client dependencies if needed
+if [ ! -d "node_modules" ]; then
+    echo -e "${YELLOW}Installing client dependencies...${NC}"
+    bun install
+fi
+
 bun run dev &
 CLIENT_PID=$!
 


### PR DESCRIPTION
- Add node_modules check for both server and client directories
- Install dependencies automatically using bun install when missing
- Update README.md to document auto-installation feature
- Improves first-time setup experience for new users

This ensures the system starts successfully even when dependencies haven't been manually installed, reducing setup friction.

🤖 Generated with [Claude Code](https://claude.ai/code)
(And reviewed by a human being 😎) 