### PR TITLE
global .claude/settings.json for all projects

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,11 +6,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run .claude/hooks/pre_tool_use.py"
+            "command": "uv run ~/.claude/hooks/pre_tool_use.py"
           },
           {
             "type": "command",
-            "command": "uv run .claude/hooks/send_event.py --source-app cc-hook-multi-agent-obvs --event-type PreToolUse --summarize"
+            "command": "uv run ~/.claude/hooks/send_event.py --source-app $(basename $CLAUDE_PROJECT_DIR) --event-type PreToolUse --summarize"
           }
         ]
       }
@@ -21,11 +21,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run .claude/hooks/post_tool_use.py"
+            "command": "uv run ~/.claude/hooks/post_tool_use.py"
           },
           {
             "type": "command",
-            "command": "uv run .claude/hooks/send_event.py --source-app cc-hook-multi-agent-obvs --event-type PostToolUse --summarize"
+            "command": "uv run ~/.claude/hooks/send_event.py --source-app $(basename $CLAUDE_PROJECT_DIR) --event-type PostToolUse --summarize"
           }
         ]
       }
@@ -36,11 +36,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run .claude/hooks/notification.py --notify "
+            "command": "uv run ~/.claude/hooks/notification.py --notify "
           },
           {
             "type": "command",
-            "command": "uv run .claude/hooks/send_event.py --source-app cc-hook-multi-agent-obvs --event-type Notification --summarize"
+            "command": "uv run ~/.claude/hooks/send_event.py --source-app $(basename $CLAUDE_PROJECT_DIR) --event-type Notification --summarize"
           }
         ]
       }
@@ -51,11 +51,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run .claude/hooks/stop.py --chat"
+            "command": "uv run ~/.claude/hooks/stop.py --chat"
           },
           {
             "type": "command",
-            "command": "uv run .claude/hooks/send_event.py --source-app cc-hook-multi-agent-obvs --event-type Stop --add-chat"
+            "command": "uv run ~/.claude/hooks/send_event.py --source-app $(basename $CLAUDE_PROJECT_DIR) --event-type Stop --add-chat"
           }
         ]
       }
@@ -66,11 +66,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run .claude/hooks/subagent_stop.py"
+            "command": "uv run ~/.claude/hooks/subagent_stop.py"
           },
           {
             "type": "command",
-            "command": "uv run .claude/hooks/send_event.py --source-app cc-hook-multi-agent-obvs --event-type SubagentStop"
+            "command": "uv run ~/.claude/hooks/send_event.py --source-app $(basename $CLAUDE_PROJECT_DIR) --event-type SubagentStop"
           }
         ]
       }
@@ -81,7 +81,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run .claude/hooks/send_event.py --source-app cc-hook-multi-agent-obvs --event-type PreCompact"
+            "command": "uv run ~/.claude/hooks/send_event.py --source-app $(basename $CLAUDE_PROJECT_DIR) --event-type PreCompact"
           }
         ]
       }
@@ -91,11 +91,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run .claude/hooks/user_prompt_submit.py --log-only"
+            "command": "uv run ~/.claude/hooks/user_prompt_submit.py --log-only"
           },
           {
             "type": "command",
-            "command": "uv run .claude/hooks/send_event.py --source-app cc-hook-multi-agent-obvs --event-type UserPromptSubmit --summarize"
+            "command": "uv run ~/.claude/hooks/send_event.py --source-app $(basename $CLAUDE_PROJECT_DIR) --event-type UserPromptSubmit --summarize"
           }
         ]
       }


### PR DESCRIPTION
This modification allows the hooks to be set in the global ~/.claude/settings.json and it will work for any project. The hook call provides the project directory which is used to extract the tag for the project.