### PR TITLE
feat: add block-no-verify hook to prevent bypassing git hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,15 @@
   "hooks": {
     "PreToolUse": [
       {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx --yes block-no-verify@1.1.2"
+          }
+        ]
+      },
+      {
         "matcher": "",
         "hooks": [
           {


### PR DESCRIPTION
Closes disler/claude-code-hooks-multi-agent-observability/issues/37

Adds block-no-verify@1.1.2 as a PreToolUse hook in .claude/settings.json to prevent Claude Code agents from bypassing git hooks via the bypass flag. The hook runs before every Bash tool call and exits non-zero if the bypass flag is detected.

This is a natural fit for this hooks reference repo: anyone copying the .claude directory into their own project benefits automatically from the guard. Blocked attempts will also appear in the observability dashboard alongside all other hook events.

Package: https://github.com/tupe12334/block-no-verify

Disclosure: I am the author and maintainer of block-no-verify.