### PR TITLE
fix: send_event.py exits 0 on JSON parse error (fixes #30)

### DIFF
--- a/.claude/hooks/send_event.py
+++ b/.claude/hooks/send_event.py
@@ -71,7 +71,7 @@ def main():
         input_data = json.load(sys.stdin)
     except json.JSONDecodeError as e:
         print(f"Failed to parse JSON input: {e}", file=sys.stderr)
-        sys.exit(1)
+        sys.exit(0)  # Exit 0 to not block Claude Code operations
     
     # Extract model name from transcript (with caching)
     session_id = input_data.get('session_id', 'unknown')

--- a/apps/demo-cc-agent/.claude/hooks/send_event.py
+++ b/apps/demo-cc-agent/.claude/hooks/send_event.py
@@ -65,7 +65,7 @@ def main():
         input_data = json.load(sys.stdin)
     except json.JSONDecodeError as e:
         print(f"Failed to parse JSON input: {e}", file=sys.stderr)
-        sys.exit(1)
+        sys.exit(0)  # Exit 0 to not block Claude Code operations
     
     # Prepare event data for server
     event_data = {


### PR DESCRIPTION
- `send_event.py` exits with code 1 on JSON parse error, which blocks ALL Bash operations when hooks are chained
- Changed `sys.exit(1)` to `sys.exit(0)` to match the stated design principle on line 178: "Always exit with 0 to not block Claude Code operations"
- Applied fix to both `.claude/hooks/send_event.py` and `apps/demo-cc-agent/.claude/hooks/send_event.py`
When multiple hooks are chained in PreToolUse configuration, the first hook consumes stdin. `send_event.py` then gets empty stdin, triggers a `json.JSONDecodeError`, and exits with code 1. Claude Code interprets exit 1 as a hook error but still processes it as a failure signal, causing all subsequent Bash commands to fail.
One-line change per file: `sys.exit(1)` → `sys.exit(0)` in the JSON parse error handler.
Fixes #30