### PR TITLE
Fix UnicodeDecodeError on Windows by forcing UTF-8 on hook file reads

### DIFF
--- a/.claude/hooks/notification.py
+++ b/.claude/hooks/notification.py
@@ -105,7 +105,7 @@ def main():
 
         # Read existing log data or initialize empty list
         if log_file.exists():
-            with open(log_file, 'r') as f:
+            with open(log_file, 'r', encoding="utf-8", errors="replace") as f:
                 try:
                     log_data = json.load(f)
                 except (json.JSONDecodeError, ValueError):

--- a/.claude/hooks/permission_request.py
+++ b/.claude/hooks/permission_request.py
@@ -23,7 +23,7 @@ def main():
 
         # Read existing log data or initialize empty list
         if log_path.exists():
-            with open(log_path, 'r') as f:
+            with open(log_path, 'r', encoding="utf-8", errors="replace") as f:
                 try:
                     log_data = json.load(f)
                 except (json.JSONDecodeError, ValueError):

--- a/.claude/hooks/post_tool_use.py
+++ b/.claude/hooks/post_tool_use.py
@@ -28,7 +28,7 @@ def main():
 
         # Read existing log data or initialize empty list
         if log_path.exists():
-            with open(log_path, 'r') as f:
+            with open(log_path, 'r', encoding="utf-8", errors="replace") as f:
                 try:
                     log_data = json.load(f)
                 except (json.JSONDecodeError, ValueError):

--- a/.claude/hooks/post_tool_use_failure.py
+++ b/.claude/hooks/post_tool_use_failure.py
@@ -23,7 +23,7 @@ def main():
 
         # Read existing log data or initialize empty list
         if log_path.exists():
-            with open(log_path, 'r') as f:
+            with open(log_path, 'r', encoding="utf-8", errors="replace") as f:
                 try:
                     log_data = json.load(f)
                 except (json.JSONDecodeError, ValueError):

--- a/.claude/hooks/pre_compact.py
+++ b/.claude/hooks/pre_compact.py
@@ -29,7 +29,7 @@ def log_pre_compact(input_data, custom_instructions):
 
     # Read existing log data or initialize empty list
     if log_file.exists():
-        with open(log_file, 'r') as f:
+        with open(log_file, 'r', encoding="utf-8", errors="replace") as f:
             try:
                 log_data = json.load(f)
             except (json.JSONDecodeError, ValueError):

--- a/.claude/hooks/pre_tool_use.py
+++ b/.claude/hooks/pre_tool_use.py
@@ -346,7 +346,7 @@ def main():
 
         # Read existing log data or initialize empty list
         if log_path.exists():
-            with open(log_path, 'r') as f:
+            with open(log_path, 'r', encoding="utf-8", errors="replace") as f:
                 try:
                     log_data = json.load(f)
                 except (json.JSONDecodeError, ValueError):

--- a/.claude/hooks/send_event.py
+++ b/.claude/hooks/send_event.py
@@ -150,7 +150,7 @@ def main():
             # Read .jsonl file and convert to JSON array
             chat_data = []
             try:
-                with open(transcript_path, 'r') as f:
+                with open(transcript_path, 'r', encoding="utf-8", errors="replace") as f:
                     for line in f:
                         line = line.strip()
                         if line:

--- a/.claude/hooks/session_end.py
+++ b/.claude/hooks/session_end.py
@@ -30,7 +30,7 @@ def log_session_end(input_data, reason):
 
     # Read existing log data or initialize empty list
     if log_file.exists():
-        with open(log_file, 'r') as f:
+        with open(log_file, 'r', encoding="utf-8", errors="replace") as f:
             try:
                 log_data = json.load(f)
             except (json.JSONDecodeError, ValueError):
@@ -63,7 +63,7 @@ def save_session_statistics(input_data):
         message_count = 0
         if transcript_path and Path(transcript_path).exists():
             try:
-                with open(transcript_path, 'r') as f:
+                with open(transcript_path, 'r', encoding="utf-8", errors="replace") as f:
                     # JSONL format - count lines
                     message_count = sum(1 for _ in f)
             except Exception:
@@ -75,7 +75,7 @@ def save_session_statistics(input_data):
         stats_file = stats_dir / 'session_statistics.json'
 
         if stats_file.exists():
-            with open(stats_file, 'r') as f:
+            with open(stats_file, 'r', encoding="utf-8", errors="replace") as f:
                 try:
                     stats = json.load(f)
                 except (json.JSONDecodeError, ValueError):

--- a/.claude/hooks/session_start.py
+++ b/.claude/hooks/session_start.py
@@ -30,7 +30,7 @@ def log_session_start(input_data):
 
     # Read existing log data or initialize empty list
     if log_file.exists():
-        with open(log_file, 'r') as f:
+        with open(log_file, 'r', encoding="utf-8", errors="replace") as f:
             try:
                 log_data = json.load(f)
             except (json.JSONDecodeError, ValueError):
@@ -133,7 +133,7 @@ def load_development_context(source, agent_type=""):
     for file_path in context_files:
         if Path(file_path).exists():
             try:
-                with open(file_path, 'r') as f:
+                with open(file_path, 'r', encoding="utf-8", errors="replace") as f:
                     content = f.read().strip()
                     if content:
                         context_parts.append(f"\n--- Content from {file_path} ---")

--- a/.claude/hooks/stop.py
+++ b/.claude/hooks/stop.py
@@ -168,7 +168,7 @@ def main():
 
         # Read existing log data or initialize empty list
         if log_path.exists():
-            with open(log_path, "r") as f:
+            with open(log_path, "r", encoding="utf-8", errors="replace") as f:
                 try:
                     log_data = json.load(f)
                 except (json.JSONDecodeError, ValueError):
@@ -195,7 +195,7 @@ def main():
                 # Read .jsonl file and convert to JSON array
                 chat_data = []
                 try:
-                    with open(transcript_path, "r") as f:
+                    with open(transcript_path, "r", encoding="utf-8", errors="replace") as f:
                         for line in f:
                             line = line.strip()
                             if line:

--- a/.claude/hooks/subagent_start.py
+++ b/.claude/hooks/subagent_start.py
@@ -23,7 +23,7 @@ def main():
 
         # Read existing log data or initialize empty list
         if log_path.exists():
-            with open(log_path, 'r') as f:
+            with open(log_path, 'r', encoding="utf-8", errors="replace") as f:
                 try:
                     log_data = json.load(f)
                 except (json.JSONDecodeError, ValueError):

--- a/.claude/hooks/subagent_stop.py
+++ b/.claude/hooks/subagent_stop.py
@@ -109,7 +109,7 @@ def main():
 
         # Read existing log data or initialize empty list
         if log_path.exists():
-            with open(log_path, "r") as f:
+            with open(log_path, "r", encoding="utf-8", errors="replace") as f:
                 try:
                     log_data = json.load(f)
                 except (json.JSONDecodeError, ValueError):
@@ -139,7 +139,7 @@ def main():
                 # Read .jsonl file and convert to JSON array
                 chat_data = []
                 try:
-                    with open(transcript_path, "r") as f:
+                    with open(transcript_path, "r", encoding="utf-8", errors="replace") as f:
                         for line in f:
                             line = line.strip()
                             if line:

--- a/.claude/hooks/user_prompt_submit.py
+++ b/.claude/hooks/user_prompt_submit.py
@@ -30,7 +30,7 @@ def log_user_prompt(session_id, input_data):
 
     # Read existing log data or initialize empty list
     if log_file.exists():
-        with open(log_file, "r") as f:
+        with open(log_file, "r", encoding="utf-8", errors="replace") as f:
             try:
                 log_data = json.load(f)
             except (json.JSONDecodeError, ValueError):
@@ -59,7 +59,7 @@ def manage_session_data(session_id, prompt, name_agent=False):
 
     if session_file.exists():
         try:
-            with open(session_file, "r") as f:
+            with open(session_file, "r", encoding="utf-8", errors="replace") as f:
                 session_data = json.load(f)
         except (json.JSONDecodeError, ValueError):
             session_data = {"session_id": session_id, "prompts": []}

--- a/.claude/hooks/utils/model_extractor.py
+++ b/.claude/hooks/utils/model_extractor.py
@@ -34,7 +34,7 @@ def get_model_from_transcript(session_id: str, transcript_path: str, ttl: int = 
     # Try to read from cache (only if caching is enabled)
     if ENABLE_CACHING and cache_file.exists():
         try:
-            with open(cache_file, 'r') as f:
+            with open(cache_file, 'r', encoding="utf-8", errors="replace") as f:
                 cache_data = json.load(f)
 
             # Check if cache is still fresh
@@ -83,7 +83,7 @@ def extract_model_from_transcript(transcript_path: str) -> str:
     try:
         # Read transcript file in reverse to find most recent assistant message
         # We'll read the whole file since we need to find the LAST occurrence
-        with open(transcript_path, 'r') as f:
+        with open(transcript_path, 'r', encoding="utf-8", errors="replace") as f:
             lines = f.readlines()
 
         # Iterate in reverse to find most recent assistant message with model


### PR DESCRIPTION
## Problem

On Windows, Python's default `open()` text mode uses the system codepage (cp1252 in en-US locales) rather than UTF-8. Claude Code's transcript JSONL files, session log JSON files, and stats caches routinely contain non-cp1252 bytes (emoji, smart quotes, em-dashes, etc.), which crashes the hook scripts with:

```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 2131: character maps to <undefined>
```

Most visibly this aborts the **Stop** hook chain, because `utils/model_extractor.extract_model_from_transcript()` reads the entire transcript with `f.readlines()` (line 86):

```
● Ran 2 stop hooks (ctrl+o to expand)
  ⎿  Stop hook error: Failed with non-blocking status code: Traceback (most recent call last):
    File "C:\Users\<user>\.claude\hooks\observability\send_event.py", line 181, in <module>
      main()
    File "C:\Users\<user>\.claude\hooks\observability\send_event.py", line 81, in main
      model_name = get_model_from_transcript(session_id, transcript_path)
    File "C:\Users\<user>\.claude\hooks\observability\utils\model_extractor.py", line 49, in get_model_from_transcript
      model_name = extract_model_from_transcript(transcript_path)
    File "C:\Users\<user>\.claude\hooks\observability\utils\model_extractor.py", line 87, in extract_model_from_transcript
      lines = f.readlines()
    File "...\Lib\encodings\cp1252.py", line 23, in decode
      return codecs.charmap_decode(input,self.errors,decoding_table)[0]
  UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 2131: character maps to <undefined>
```

The same `open(<path>, 'r')` pattern (no explicit `encoding`) is repeated in 13 other hook scripts, so any of them can hit the same wall on Windows depending on what bytes happen to be in the file.

## Fix

Adds `encoding="utf-8", errors="replace"` to every text-mode `open()` call in `.claude/hooks/`. UTF-8 is the correct format for these files (Claude Code writes them as UTF-8 on every platform). `errors="replace"` is chosen over `strict` so a single corrupt byte doesn't abort the entire hook chain — observability tooling shouldn't be a blocker for the user's session.

Behavior on macOS and Linux is unchanged: their default locale is already UTF-8, so the explicit kwargs are a no-op there.

## Files touched (14)

```
.claude/hooks/notification.py
.claude/hooks/permission_request.py
.claude/hooks/post_tool_use.py
.claude/hooks/post_tool_use_failure.py
.claude/hooks/pre_compact.py
.claude/hooks/pre_tool_use.py
.claude/hooks/send_event.py
.claude/hooks/session_end.py
.claude/hooks/session_start.py
.claude/hooks/stop.py
.claude/hooks/subagent_start.py
.claude/hooks/subagent_stop.py
.claude/hooks/user_prompt_submit.py
.claude/hooks/utils/model_extractor.py
```

Each change is the same one-line transformation:

```diff
- with open(<path>, 'r') as f:
+ with open(<path>, 'r', encoding="utf-8", errors="replace") as f:
```

## Test plan

- [x] Reproduced on Windows 11 + Python 3.14 (uv-managed): Stop hook crashed with the cp1252 traceback above on a transcript containing smart quotes
- [x] Verified fix: same session, after patch, all 14 hook scripts run cleanly and events stream to the dashboard
- [ ] No regression on macOS/Linux: changes are no-ops in UTF-8 locales, but a maintainer with that environment may want to confirm

## Related

This is the fix I'm running locally on a Windows 11 + Git Bash setup. The root cause was the cp1252 default — flagging it here in case other Windows users have hit the same thing.